### PR TITLE
(chore) Remove test results app from build config file

### DIFF
--- a/configuration/build-config.json
+++ b/configuration/build-config.json
@@ -24,7 +24,6 @@
     "@openmrs/esm-patient-orders-app": "next",
     "@openmrs/esm-patient-attachments-app": "next",
     "@openmrs/esm-patient-medications-app": "next",
-    "@openmrs/esm-patient-test-results-app": "next",
     "@openmrs/esm-dispensing-app": "next",
     "@openmrs/esm-service-queues-app": "next",
     "@openmrs/esm-laboratory-app": "next",


### PR DESCRIPTION
The test results app got renamed to `esm-labs-app` in https://github.com/openmrs/openmrs-distro-referenceapplication/commit/7a5c07f47fcfedaf9bbf78bbfddce6b64e4295fb. This PR removes it from the build config, fixing an issue where duplicated dashboard links named `Results Viewer` show up in the Patient Chart left panel.

![CleanShot 2024-02-28 at 12  49 08@2x](https://github.com/AMPATH/openmrs-config-amrs/assets/8509731/aa65b703-1ba6-42dd-a651-e2f3a83a615d)

