### PR TITLE
(chore) Make service worker opt-in for local dev

### DIFF
--- a/configuration/build-config.json
+++ b/configuration/build-config.json
@@ -37,5 +37,6 @@
   "spaPath": "/amrs/spa",
   "apiUrl": "/amrs",
   "configUrls": ["${openmrsSpaBase}/config.json"],
-  "importmap": "/amrs/spa/importmap.json"
+  "importmap": "/amrs/spa/importmap.json",
+  "supportOffline": false
 }


### PR DESCRIPTION
This PR makes it so that offline mode, and more specifically, the O3 service worker is [disabled out of the box](https://github.com/openmrs/openmrs-esm-core/pull/780).  Presently, our service worker implementation is buggy and slow. This slowdown is most noticeable when running local dev servers. Until the offline mode implementation is reworked, our advice is to turn it off by default using this config property. Read the linked PR for more context.